### PR TITLE
Make gallery navigation active indicator shows properly

### DIFF
--- a/_css/_menu.scss
+++ b/_css/_menu.scss
@@ -105,7 +105,10 @@
     background: url('/assets/images/theme/bg-qtproducts-shadow-gallery-menu.png') no-repeat center bottom;
     li a {
       &:hover, &.active {
-        background: url('/assets/images/theme/subnav-small-arrow.png') no-repeat center bottom;
+        background-image: url('/assets/images/theme/subnav-small-arrow.png');
+        background-repeat: no-repeat;
+        background-position-x: center;
+        background-position-y: bottom;
       }
     }
   }
@@ -123,6 +126,12 @@
       }
     }
   }
+}
+
+// Override foundation styling so the triangle that shows active item is displayed properly
+.galleryNav__list,
+.menu-centered>.menu.galleryNav__list, {
+  vertical-align: initial;
 }
 
 // Hack for IE9 and lower.

--- a/_includes/navigation-gallery-small.html
+++ b/_includes/navigation-gallery-small.html
@@ -1,8 +1,8 @@
 {% assign current = page.path | downcase | split: '/' %}
 {% assign current = current[1] %}
 
-<div class="navigation-small menu-centered">
-  <ul class="vertical medium-horizontal menu">
+<div class="galleryNav navigation-small menu-centered">
+  <ul class="galleryNav__list vertical medium-horizontal menu">
     <li>
       <a href="/gallery/rock-panels/"{% if current == "rock" or current == "rock-panels" %} class="active"{% endif %}>
         <img alt="Rock Panels" title="menu-small-rock.png" src="/assets/images/theme/menu-small-rock.png" /> Rock Panels


### PR DESCRIPTION
Resolves #231 
Checkout `active-gallery-menu` to see the result.