### PR TITLE
Add top bar with floating down text

### DIFF
--- a/_css/_layout.scss
+++ b/_css/_layout.scss
@@ -22,7 +22,6 @@
 
 #header {
   background: url("/assets/images/theme/header-top-angle-lines.png") repeat-x;
-  border-top: 5px map-get($foundation-palette, primary) solid;
   padding-top: 1rem;
   border-bottom: 1px solid;
   border-bottom-color: #cccccc;

--- a/_css/_modules.scss
+++ b/_css/_modules.scss
@@ -671,3 +671,65 @@ cite {
     }
   }
 }
+
+.topBar {
+  background-color: #E4E4E4;
+  color: map-get($foundation-palette, primary);
+  font-family: 'Open Sans', 'sans-serif';
+  font-size: 14px;
+
+  &__container {
+    @include grid-row;
+
+    opacity: 1;
+    transform: translateY(0%);
+    transition: transform 1s ease-out 1s;
+
+    // Class to be removed with JavaScript to show float down effect
+    &.startLiftedAndTransparent {
+      transform: translateY(-100%);
+      opacity: 0;
+    }
+  }
+
+  &__leftText,
+  &__rightText {
+    overflow: hidden;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    text-overflow: ellipsis;
+
+    white-space: nowrap;
+  }
+
+  &__leftText {
+    @include grid-column(8);
+
+    @include breakpoint(medium) {
+      @include grid-column(9);
+    }
+
+    @include breakpoint(small) {
+      @include grid-column(12);
+    }
+  }
+
+  &__rightText {
+    @include grid-column(4);
+    @include show-for(medium);
+
+    text-align: right;
+    text-transform: uppercase;
+    font-weight: bold;
+
+    @include breakpoint(medium) {
+      @include grid-column(3);
+    }
+  }
+}
+
+.link {
+  &--small {
+    font-size: 85%;
+  }
+}

--- a/_css/_modules.scss
+++ b/_css/_modules.scss
@@ -676,7 +676,7 @@ cite {
   background-color: #E4E4E4;
   color: map-get($foundation-palette, primary);
   font-family: 'Open Sans', 'sans-serif';
-  font-size: 14px;
+  font-size: 13px;
 
   &__container {
     @include grid-row;

--- a/_css/_modules.scss
+++ b/_css/_modules.scss
@@ -735,7 +735,7 @@ cite {
 }
 
 .enterByFloatingDown {
-  animation: floatDown 4s 1;
+  animation: floatDown 2s 1;
 }
 
 @keyframes floatDown {

--- a/_css/_modules.scss
+++ b/_css/_modules.scss
@@ -733,3 +733,18 @@ cite {
     font-size: 85%;
   }
 }
+
+.enterByFloatingDown {
+  animation: floatDown 4s 1;
+}
+
+@keyframes floatDown {
+  0% {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0%);
+    opacity: 1;
+  }
+}

--- a/_css/_settings.scss
+++ b/_css/_settings.scss
@@ -616,6 +616,6 @@ $tooltip-radius: $global-radius;
 $topbar-padding: 0.5rem;
 $topbar-background: $light-gray;
 $topbar-submenu-background: $topbar-background;
-$topbar-title-spacing: 0.5rem 1rem 0.5rem 0;
+$topbar-title-spacing: 0.3rem 1rem 0.3rem 0;
 $topbar-input-width: 200px;
 $topbar-unstack-breakpoint: medium;

--- a/_includes/top-bar.html
+++ b/_includes/top-bar.html
@@ -1,5 +1,5 @@
 <div class="topBar">
-  <div class="topBar__container startLiftedAndTransparent">
+  <div class="topBar__container enterByFloatingDown">
     <div
       class="topBar__leftText"
       title="We serve clients nationwide, call us at (855) 696-9802 to reserve your samples."

--- a/_includes/top-bar.html
+++ b/_includes/top-bar.html
@@ -10,7 +10,7 @@
       class="topBar__rightText"
       title="Request a sample"
     >
-      <a class="link--small" href="#">Request a sample</a>
+      <a class="link--small" href="/how-to-buy/">Request a sample</a>
     </div>
   </div>
 </div>

--- a/_includes/top-bar.html
+++ b/_includes/top-bar.html
@@ -10,7 +10,7 @@
       class="topBar__rightText"
       title="Request a sample"
     >
-      <a class="link--small" href="/how-to-buy/">Request a sample</a>
+      <a class="link--small" href="/contact-us/">Request a sample</a>
     </div>
   </div>
 </div>

--- a/_includes/top-bar.html
+++ b/_includes/top-bar.html
@@ -1,0 +1,16 @@
+<div class="topBar">
+  <div class="topBar__container startLiftedAndTransparent">
+    <div
+      class="topBar__leftText"
+      title="We serve clients nationwide, call us at (855) 696-9802 to reserve your samples."
+    >
+      We serve clients nationwide, call us at <a class="link" href="tel:+18556969802">(855) 696-9802</a> to reserve your samples.
+    </div>
+    <div
+      class="topBar__rightText"
+      title="Request a sample"
+    >
+      <a class="link--small" href="#">Request a sample</a>
+    </div>
+  </div>
+</div>

--- a/_includes/top-bar.html
+++ b/_includes/top-bar.html
@@ -1,4 +1,4 @@
-<div class="topBar">
+<div class="topBar show-for-medium">
   <div class="topBar__container enterByFloatingDown">
     <div
       class="topBar__leftText"
@@ -10,7 +10,7 @@
       class="topBar__rightText"
       title="Request a sample"
     >
-      <a class="link--small" href="/contact-us/">Request a sample</a>
+      <a class="link--small" href="/how-to-buy/">Request a sample</a>
     </div>
   </div>
 </div>

--- a/_js/top_bar.js
+++ b/_js/top_bar.js
@@ -1,7 +1,9 @@
 $(function($, global) {
 
-  var topBar = $('.topBar');
-  var elementsToFloatDown = topBar.find('.startLiftedAndTransparent');
-  elementsToFloatDown.removeClass('startLiftedAndTransparent');
+  if (!sessionStorage.getItem('hasVisited')) {
+    sessionStorage.setItem('hasVisited', 'true');
+  } else {
+    $('.topBar__container.enterByFloatingDown').removeClass('enterByFloatingDown');
+  }
 
 }(jQuery, window));

--- a/_js/top_bar.js
+++ b/_js/top_bar.js
@@ -1,0 +1,7 @@
+$(function($, global) {
+
+  var topBar = $('.topBar');
+  var elementsToFloatDown = topBar.find('.startLiftedAndTransparent');
+  elementsToFloatDown.removeClass('startLiftedAndTransparent');
+
+}(jQuery, window));

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,7 @@
     </ul>
   </div>
   <div class="off-canvas-content" data-off-canvas-content>
+    {% include top-bar.html %}
     {% include header.html %}
     <div id="norstone-menu" class="menu-centered show-for-large">
       <ul class="vertical large-horizontal menu">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,6 +57,7 @@ gulp.task('js', function() {
     './bower_components/owl.carousel2.thumbs/dist/owl.carousel2.thumbs.js',
     './_js/norstone.js',
     './_js/thumbnail_slider.js',
+    './_js/top_bar.js',
   ])
     .pipe(concat('norstone.js'))
     .pipe(uglify())


### PR DESCRIPTION
Since there is only one set of text, float the whole container or
row down.

The top border of the header is no longer needed.