### PR TITLE
Center-align 'Local Distributor' text in how-to-buy page

### DIFF
--- a/how-to-buy.html
+++ b/how-to-buy.html
@@ -55,7 +55,7 @@ layout: default
       <div class="items-container" align="center">
         <span class="item">Pricing</span>
         <span class="item">Samples</span>
-        <span class="item"><p>Local<br>Distributor</p></span>
+        <span class="item"><p class="text-center">Local<br>Distributor</p></span>
       </div>
       <div class="contact">
         <div class="call">GIVE US A CALL</div>


### PR DESCRIPTION
Resolves #237